### PR TITLE
chore: add stale GitHub action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+on:
+  schedule:
+  - cron: "*/10 5 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 365
+        stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+        stale-pr-message: 'This PR is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+        close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+        close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+        exempt-issue-labels: 'Help Wanted, Good first issue, Never gets stale'
+        exempt-pr-labels: 'Help Wanted, Never gets stale'


### PR DESCRIPTION
Add stale action to close older issues/PR that are more than one year inactive